### PR TITLE
Build fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 all: com.Genymobile.Scrcpy.flatpak
 
-build:
+build: com.Genymobile.Scrcpy.yaml
 	flatpak-builder test com.Genymobile.Scrcpy.yaml --force-clean
 	flatpak-builder --repo=repo --force-clean test com.Genymobile.Scrcpy.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: build install run uninstall
 
+all: com.Genymobile.Scrcpy.flatpak
+
 build:
 	flatpak-builder test com.Genymobile.Scrcpy.yaml --force-clean
 	flatpak-builder --repo=repo --force-clean test com.Genymobile.Scrcpy.yaml
@@ -15,10 +17,10 @@ uninstall:
 	flatpak uninstall com.Genymobile.Scrcpy --assumeyes --delete-data
 	flatpak --user remote-delete tutorial-repo --force
 
-package:
+com.Genymobile.Scrcpy.flatpak: build
 	flatpak build-bundle repo com.Genymobile.Scrcpy.flatpak com.Genymobile.Scrcpy
 
-install: package
+install: com.Genymobile.Scrcpy.flatpak
 	flatpak --user install com.Genymobile.Scrcpy.flatpak --assumeyes
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@
 all: com.Genymobile.Scrcpy.flatpak
 
 build: com.Genymobile.Scrcpy.yaml
-	flatpak-builder test com.Genymobile.Scrcpy.yaml --force-clean
 	flatpak-builder --repo=repo --force-clean test com.Genymobile.Scrcpy.yaml
 
 test-install:

--- a/com.Genymobile.Scrcpy.yaml
+++ b/com.Genymobile.Scrcpy.yaml
@@ -14,20 +14,7 @@ cleanup-commands:
   - mkdir -p ${FLATPAK_DEST}/lib/ffmpeg
 
 modules:
-  - name: libusb
-    config-opts:
-      - "--disable-static"
-      - "--disable-udev"
-    cleanup:
-      - "/lib/*.la"
-      - "/lib/pkgconfig"
-      - "/include"
-    sources:
-      - type: archive
-        url: https://github.com/libusb/libusb/archive/v1.0.22.tar.gz
-        sha256: 3500f7b182750cd9ccf9be8b1df998f83df56a39ab264976bdb3307773e16f48
-    post-install:
-      - "install -Dm644 COPYING /app/share/licenses/libusb/COPYING"
+  - "shared-modules/libusb/libusb.json"
 
   - name: scrcpy
     buildsystem: simple


### PR DESCRIPTION
I didn't finish the work to modernise the Flatpak because I realised that `guiscrcpy` although not my cup of tea wrt looks, is already packaged in Flathub.

https://github.com/nmeum/android-tools is a fork of android-tools with cmake support added. You can build it like this RPM does:
https://src.fedoraproject.org/rpms/android-tools/tree/?h=rawhide

I also filed it against https://github.com/flathub/in.srev.guiscrcpy/issues/6